### PR TITLE
Draft instructions prompt for protocol outline preparation for llm assistance

### DIFF
--- a/llm_protocol_context/instructions.txt
+++ b/llm_protocol_context/instructions.txt
@@ -43,7 +43,7 @@ protocol_name:  # Human-readable protocol identifier
 - Use only process types defined in the provided NMDC schema JSON
 - Match protocol activities to the most appropriate process type from the schema
 - If uncertain about process type selection, choose the most specific applicable type from the schema
-- If an Process Type's attribute's value is another class, that class must comply with the schema
+- If a Process Type's attribute's value is another class, that class must comply with the schema
 
 **Required Fields:**
 - Each step must have: `id`, `type`, `name`, `description`, `has_input`, `has_output`


### PR DESCRIPTION
It's a bit wordy, but here's a starting point for the instructions to send to the LLM.  

After talking to @samobermiller I added some text that it should expect a python function to validate the output yaml.  We can remove this if we don't think it's helpful.  I would find it helpful, so I figured an LLM would too.  