### PR TITLE
Update nmdc-api-utilities calls to nmdc-client

### DIFF
--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -18,7 +18,8 @@ from minio.error import S3Error
 from nmdc_dp_utils.llm.protocol_conversion.pipeline import get_llm_yaml_outline
 from nmdc_dp_utils.llm.llm_conversation_manager import ConversationManager
 from nmdc_dp_utils.llm.llm_client import LLMClient
-from nmdc_api_utilities.calibration_search import CalibrationSearch
+from nmdc_client.calibration_search import CalibrationSearch
+from nmdc_client.api_client import get_api_base_url
 
 # Import workflow mapping defined in workflow_manager (defined before mixins import)
 from nmdc_ms_metadata_gen.metadata_generator import NMDCMetadataGenerator
@@ -78,6 +79,8 @@ WORKFLOW_DICT = {
 
 # Load environment variables from .env file
 load_dotenv()
+ENV = os.getenv("NMDC_ENV", "prod")
+API_BASE_URL = os.getenv("API_BASE_URL", get_api_base_url(env=ENV))
 
 
 def skip_if_complete(trigger_name: str, return_value=None):
@@ -2392,7 +2395,7 @@ class NMDCWorkflowBiosampleManager:
         """
         Fetch biosample attributes from NMDC API and save to CSV file.
 
-        Uses the nmdc_api_utilities package to query biosamples associated with
+        Uses the nmdc_client package to query biosamples associated with
         the study ID and saves the attributes to a CSV file in the study's
         metadata directory. Includes skip trigger to avoid re-downloading.
 
@@ -2407,7 +2410,7 @@ class NMDCWorkflowBiosampleManager:
             The CSV file is saved as 'biosample_attributes.csv' in the study's metadata directory.
             This method is automatically skipped if biosample_attributes_fetched trigger is set.
         """
-        from nmdc_api_utilities.biosample_search import BiosampleSearch
+        from nmdc_client.biosample_search import BiosampleSearch
 
         if study_id is None:
             study_id = self.config["study"]["id"]
@@ -2415,8 +2418,8 @@ class NMDCWorkflowBiosampleManager:
         self.logger.info(f"Fetching biosample attributes for study: {study_id}")
 
         try:
-            # Use nmdc_api_utilities to fetch biosamples
-            biosample_search = BiosampleSearch()
+            # Use nmdc_client to fetch biosamples
+            biosample_search = BiosampleSearch(api_base_url=API_BASE_URL)
             biosamples = biosample_search.get_record_by_filter(
                 filter=f'{{"associated_studies":"{study_id}"}}',
                 max_page_size=1000,
@@ -3810,7 +3813,7 @@ class WorkflowMetadataManager:
                 merged_df["calibration_id"] = "nmdc:calib-14-hhn3qb47"
             else:
                 calib_ref_stem = Path(calibration_ref_file_path).stem
-                cs_client = CalibrationSearch()
+                cs_client = CalibrationSearch(api_base_url=API_BASE_URL)
                 try:
                     c = cs_client.get_record_by_attribute(
                         attribute_name="name",
@@ -4735,8 +4738,8 @@ class WorkflowMetadataManager:
         This method:
         1. Loads .json metadata packages from nmdc_submission_packages directory
         2. Verifies all id fields have "-11-" tag (production minted IDs)
-        3. Validates JSON using validate_json from nmdc_api_utilities
-        4. Submits JSON using submit_json from nmdc_api_utilities
+        3. Validates JSON using validate_json from nmdc_client
+        4. Submits JSON using submit_json from nmdc_client
         5. Submits material processing metadata first, waits 1 minute, then submits workflow metadata
 
         Args:
@@ -4754,8 +4757,8 @@ class WorkflowMetadataManager:
             - 1 minute wait time after material processing before workflow metadata
             - Fails immediately on any error (does not try other files)
         """
-        from nmdc_api_utilities.metadata import Metadata
-        from nmdc_api_utilities.auth import NMDCAuth
+        from nmdc_client.metadata import Metadata
+        from nmdc_client.auth import NMDCAuth
         import time
 
         self.logger.info(f"Submitting metadata packages to {environment} environment...")
@@ -4957,7 +4960,7 @@ class WorkflowMetadataManager:
         Returns:
             True if IDs already exist (already submitted), False if new IDs
         """
-        from nmdc_api_utilities.nmdc_search import NMDCSearch
+        from nmdc_client.nmdc_search import NMDCSearch
         import random
         import logging
         
@@ -4971,15 +4974,15 @@ class WorkflowMetadataManager:
         self.logger.info(f"Checking if {len(primary_ids)} IDs already exist in {environment} database...")
         
         # Initialize NMDC search client
-        search = NMDCSearch(env=environment)
+        search = NMDCSearch(api_base_url=API_BASE_URL)
         
         # Check a random sample of IDs (4 IDs to avoid too many API calls)
         sample_size = min(4, len(primary_ids))
         sample_ids = random.sample(list(primary_ids), sample_size)
         
-        # Temporarily suppress error logging from nmdc_api_utilities
+        # Temporarily suppress error logging from nmdc_client
         # since 404s are expected for new IDs
-        nmdc_logger = logging.getLogger("nmdc_api_utilities")
+        nmdc_logger = logging.getLogger("nmdc_client")
         original_level = nmdc_logger.level
         nmdc_logger.setLevel(logging.CRITICAL)
         
@@ -5291,6 +5294,7 @@ class WorkflowMetadataManager:
         # Always use prod environment for ID minting to ensure consistency
         # across material processing and workflow metadata generation
         os.environ["NMDC_ENV"] = "prod"
+        API_BASE_URL = os.getenv("API_BASE_URL", get_api_base_url(env=ENV))
         self.logger.info("Set NMDC_ENV=prod for ID minting across all metadata generation")
         
         # Clean up macOS metadata files before processing

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -4974,7 +4974,7 @@ class WorkflowMetadataManager:
         self.logger.info(f"Checking if {len(primary_ids)} IDs already exist in {environment} database...")
         
         # Initialize NMDC search client
-        search = NMDCSearch(api_base_url=API_BASE_URL)
+        search = NMDCSearch(api_base_url=get_api_base_url(env=environment))
         
         # Check a random sample of IDs (4 IDs to avoid too many API calls)
         sample_size = min(4, len(primary_ids))
@@ -5293,8 +5293,9 @@ class WorkflowMetadataManager:
         """
         # Always use prod environment for ID minting to ensure consistency
         # across material processing and workflow metadata generation
+        # Hold current environment in case we need to restore it later
+        current_env = os.getenv("NMDC_ENV")
         os.environ["NMDC_ENV"] = "prod"
-        API_BASE_URL = os.getenv("API_BASE_URL", get_api_base_url(env=ENV))
         self.logger.info("Set NMDC_ENV=prod for ID minting across all metadata generation")
         
         # Clean up macOS metadata files before processing
@@ -5317,9 +5318,12 @@ class WorkflowMetadataManager:
             self.logger.error("Failed to generate NMDC metadata packages")
             return False
 
+        # Restore environment variable post minting, just in case?
+        if current_env is not None:
+            os.environ["NMDC_ENV"] = current_env
+
         self.logger.info("All metadata generation steps completed successfully")
         return True
-
 
 class LLMWorkflowManagerMixin:
     """

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2419,7 +2419,7 @@ class NMDCWorkflowBiosampleManager:
 
         try:
             # Use nmdc_client to fetch biosamples
-            biosample_search = BiosampleSearch(api_base_url=API_BASE_URL)
+            biosample_search = BiosampleSearch()
             biosamples = biosample_search.get_record_by_filter(
                 filter=f'{{"associated_studies":"{study_id}"}}',
                 max_page_size=1000,
@@ -3813,7 +3813,7 @@ class WorkflowMetadataManager:
                 merged_df["calibration_id"] = "nmdc:calib-14-hhn3qb47"
             else:
                 calib_ref_stem = Path(calibration_ref_file_path).stem
-                cs_client = CalibrationSearch(api_base_url=API_BASE_URL)
+                cs_client = CalibrationSearch()
                 try:
                     c = cs_client.get_record_by_attribute(
                         attribute_name="name",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nmdc-mass-spectrometry-metadata-generation @ git+https://github.com/microbiomedata/nmdc_mass_spectrometry_metadata_generation.git@2.8.1
+nmdc-mass-spectrometry-metadata-generation @ git+https://github.com/microbiomedata/nmdc_mass_spectrometry_metadata_generation.git@2.8.2
 minio==7.2.18
 miniwdl
 openai==2.14.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def mock_subprocess_run():
 @pytest.fixture
 def mock_biosample_search():
     """Mock NMDC API BiosampleSearch for biosample attribute tests."""
-    with patch('nmdc_api_utilities.biosample_search.BiosampleSearch') as mock_search:
+    with patch('nmdc_client.biosample_search.BiosampleSearch') as mock_search:
         yield mock_search
 
 

--- a/tests/test_metadata_submission.py
+++ b/tests/test_metadata_submission.py
@@ -3,7 +3,7 @@ Unit tests for submit_metadata_packages functionality.
 
 Tests the metadata submission workflow including:
 - Production ID verification (-11- tag)
-- JSON validation using nmdc_api_utilities
+- JSON validation using nmdc_client
 - JSON submission to dev/prod environments
 - Material processing submission before workflow metadata
 - Proper error handling
@@ -112,8 +112,8 @@ class TestMetadataSubmission:
         assert result is True
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_success(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids
@@ -171,8 +171,8 @@ class TestMetadataSubmission:
         assert mock_metadata_instance.submit_json.call_count == 2
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_prod_environment(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids
@@ -267,8 +267,8 @@ class TestMetadataSubmission:
         assert result is False
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_validation_failure(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids
@@ -299,8 +299,8 @@ class TestMetadataSubmission:
         assert result is False
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_submission_failure(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids
@@ -332,8 +332,8 @@ class TestMetadataSubmission:
         assert result is False
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     @patch('time.sleep')
     def test_submit_metadata_packages_waits_after_material_processing(
         self, mock_sleep, mock_auth_class, mock_metadata_class, lcms_config_file, 
@@ -373,8 +373,8 @@ class TestMetadataSubmission:
         mock_sleep.assert_called_once_with(60)
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_to_dev_wrapper(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids
@@ -409,8 +409,8 @@ class TestMetadataSubmission:
         assert manager.should_skip("metadata_submitted_dev") is True
 
     @patch.dict(os.environ, {"NMDC_USERNAME": "test_user", "NMDC_PASSWORD": "test_pass"})
-    @patch('nmdc_api_utilities.metadata.Metadata')
-    @patch('nmdc_api_utilities.auth.NMDCAuth')
+    @patch('nmdc_client.metadata.Metadata')
+    @patch('nmdc_client.auth.NMDCAuth')
     def test_submit_metadata_packages_to_prod_wrapper(
         self, mock_auth_class, mock_metadata_class, lcms_config_file, 
         metadata_packages_dir, sample_metadata_with_production_ids


### PR DESCRIPTION
This PR changes all references to nmdc_api_utilities package to nmdc_client and updates Search() function calls to use the new API base URL method instead of passing an environment string.