### PR TITLE
Add ability to process multiple studies in a single workflow

### DIFF
--- a/nmdc_dp_utils/workflow_manager.py
+++ b/nmdc_dp_utils/workflow_manager.py
@@ -82,7 +82,10 @@ class NMDCWorkflowManager(
         self.config = self.load_config(config_path)
         self.workflow_name = self.config["workflow"]["name"]
         self.study_name = self.config["study"]["name"]
+        # Read in study ID, make it a list of strings if it's not already
         self.study_id = self.config["study"]["id"]
+        if isinstance(self.study_id, str):
+            self.study_id = [self.study_id]
         self.base_path = Path(self.config["paths"]["base_directory"])
         self.workflow_path = self.base_path / "workflows" / f"{self.workflow_name}"
 

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2388,7 +2388,11 @@ class NMDCWorkflowBiosampleManager:
     """
 
     @skip_if_complete("biosample_attributes_fetched", return_value=True)
-    def get_biosample_attributes(self, study_id: Optional[str] = None) -> bool:
+    def get_biosample_attributes(
+        self, 
+        study_ids: Optional[list[str]] = None, 
+        use_child_studies: bool = False
+    ) -> bool:
         """
         Fetch biosample attributes from NMDC API and save to CSV file.
 
@@ -2397,8 +2401,9 @@ class NMDCWorkflowBiosampleManager:
         metadata directory. Includes skip trigger to avoid re-downloading.
 
         Args:
-            study_id: NMDC study ID (e.g., 'nmdc:sty-11-dwsv7q78').
+            study_id: List of NMDC study ID(s) (e.g., ['nmdc:sty-11-dwsv7q78']).
                      Uses config['study']['id'] if not provided.
+            use_child_studies: If True, also fetch biosamples from child studies linked to the main study ID.
 
         Returns:
             True if biosample attributes fetched successfully, False otherwise
@@ -2408,28 +2413,58 @@ class NMDCWorkflowBiosampleManager:
             This method is automatically skipped if biosample_attributes_fetched trigger is set.
         """
         from nmdc_api_utilities.biosample_search import BiosampleSearch
+        from nmdc_api_utilities.study_search import StudySearch
 
-        if study_id is None:
-            study_id = self.config["study"]["id"]
+        if study_ids is None:
+            study_ids = self.config["study"]["id"]
+            if isinstance(study_ids, str):
+                study_ids = [study_ids]
 
-        self.logger.info(f"Fetching biosample attributes for study: {study_id}")
+        # If we want to use child studies (eg. campaign or consortium),
+        # find all children for provided study IDs and add them
+        if use_child_studies:
+            study_searcher = StudySearch()
+            child_studies = []
+            for study_id in study_ids:
+                child_study_ids = study_searcher.get_record_by_filter(
+                    filter=f'{{"associated_studies":"{study_id}"}}',
+                    max_page_size=1000,
+                    fields="id,name",
+                    all_pages=True,
+                )
+                child_studies.extend(child_study_ids)
+            study_ids = study_ids + [s["id"] for s in child_studies]
+            for s in child_studies:
+                self.logger.info(f"Added child study to list: {s['id']}, {s['name']}")
 
         try:
-            # Use nmdc_api_utilities to fetch biosamples
-            biosample_search = BiosampleSearch()
-            biosamples = biosample_search.get_record_by_filter(
-                filter=f'{{"associated_studies":"{study_id}"}}',
-                max_page_size=1000,
-                fields="id,name,samp_name,description,gold_biosample_identifiers,insdc_biosample_identifiers,submitter_id,analysis_type",
-                all_pages=True,
-            )
+            # Add biosample results to a dataframe for each study ID and concatenate if multiple
+            biosample_dfs = []
+            for study_id in study_ids:
+                self.logger.info(f"Fetching biosample attributes for study: {study_id}")
 
-            if not biosamples:
-                self.logger.error(f"No biosamples found for study {study_id}")
+                # Use nmdc_api_utilities to fetch biosamples
+                biosample_search = BiosampleSearch()
+                biosamples = biosample_search.get_record_by_filter(
+                    filter=f'{{"associated_studies":"{study_id}"}}',
+                    max_page_size=1000,
+                    fields="id,name,samp_name,description,gold_biosample_identifiers,insdc_biosample_identifiers,submitter_id,analysis_type",
+                    all_pages=True,
+                )
+
+                if not biosamples:
+                    self.logger.error(f"No biosamples found for study {study_id}")
+                    return False
+
+                # Convert to DataFrame
+                biosample_dfs.append(pd.DataFrame(biosamples))
+
+            # Concatenate all biosample DataFrames if there are multiple
+            if biosample_dfs:
+                biosample_df = pd.concat(biosample_dfs, ignore_index=True)
+            else:
+                self.logger.error("No biosample data available to save.")
                 return False
-
-            # Convert to DataFrame
-            biosample_df = pd.DataFrame(biosamples)
 
             # Create metadata directory if it doesn't exist
             metadata_dir = self.workflow_path / "metadata"

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2417,8 +2417,8 @@ class NMDCWorkflowBiosampleManager:
             The CSV file is saved as 'biosample_attributes.csv' in the study's metadata directory.
             This method is automatically skipped if biosample_attributes_fetched trigger is set.
         """
-        from nmdc-client.biosample_search import BiosampleSearch
-        from nmdc-client.study_search import StudySearch
+        from nmdc_client.biosample_search import BiosampleSearch
+        from nmdc_client.study_search import StudySearch
 
         if study_ids is None:
             study_ids = self.config["study"]["id"]

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2451,7 +2451,6 @@ class NMDCWorkflowBiosampleManager:
                     fields="id,name,samp_name,description,gold_biosample_identifiers,insdc_biosample_identifiers,submitter_id,analysis_type",
                     all_pages=True,
                 )
-
                 if not biosamples:
                     self.logger.warning(f"No biosamples found for study {study_id}")
                     # Warning instead of an error - don't error out unless the final dataframe is empty
@@ -2459,10 +2458,9 @@ class NMDCWorkflowBiosampleManager:
                 # Convert to DataFrame
                 biosample_dfs.append(pd.DataFrame(biosamples))
 
-            # Concatenate all biosample DataFrames if there are multiple
-            if biosample_dfs:
-                biosample_df = pd.concat(biosample_dfs, ignore_index=True)
-            else:
+            # Concatenate all biosample DataFrames
+            biosample_df = pd.concat(biosample_dfs, ignore_index=True)
+            if biosample_df.empty:
                 self.logger.error("No biosample data available to save.")
                 return False
 

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2427,7 +2427,7 @@ class NMDCWorkflowBiosampleManager:
             child_studies = []
             for study_id in study_ids:
                 child_study_ids = study_searcher.get_record_by_filter(
-                    filter=f'{{"associated_studies":"{study_id}"}}',
+                    filter=f'{{"part_of":"{study_id}"}}',
                     max_page_size=1000,
                     fields="id,name",
                     all_pages=True,
@@ -2453,8 +2453,8 @@ class NMDCWorkflowBiosampleManager:
                 )
 
                 if not biosamples:
-                    self.logger.error(f"No biosamples found for study {study_id}")
-                    return False
+                    self.logger.warning(f"No biosamples found for study {study_id}")
+                    # Warning instead of an error - don't error out unless the final dataframe is empty
 
                 # Convert to DataFrame
                 biosample_dfs.append(pd.DataFrame(biosamples))

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2417,8 +2417,8 @@ class NMDCWorkflowBiosampleManager:
             The CSV file is saved as 'biosample_attributes.csv' in the study's metadata directory.
             This method is automatically skipped if biosample_attributes_fetched trigger is set.
         """
-        from nmdc_api_utilities.biosample_search import BiosampleSearch
-        from nmdc_api_utilities.study_search import StudySearch
+        from nmdc-client.biosample_search import BiosampleSearch
+        from nmdc-client.study_search import StudySearch
 
         if study_ids is None:
             study_ids = self.config["study"]["id"]

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2394,7 +2394,7 @@ class NMDCWorkflowBiosampleManager:
     def get_biosample_attributes(
         self, 
         study_ids: Optional[list[str]] = None, 
-        use_child_studies: bool = False
+        use_child_studies: bool = None
     ) -> bool:
         """
         Fetch biosample attributes from NMDC API and save to CSV file.

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2403,7 +2403,9 @@ class NMDCWorkflowBiosampleManager:
         Args:
             study_id: List of NMDC study ID(s) (e.g., ['nmdc:sty-11-dwsv7q78']).
                      Uses config['study']['id'] if not provided.
-            use_child_studies: If True, also fetch biosamples from child studies linked to the main study ID.
+            use_child_studies: If True, also fetch biosamples from child 
+                    studies linked to the main study ID. 
+                    Uses config['workflow']['use_child_studies'] if not provided.
 
         Returns:
             True if biosample attributes fetched successfully, False otherwise

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -2419,6 +2419,9 @@ class NMDCWorkflowBiosampleManager:
             study_ids = self.config["study"]["id"]
             if isinstance(study_ids, str):
                 study_ids = [study_ids]
+        
+        if use_child_studies is None:
+            use_child_studies = self.config["workflow"].get("use_child_studies", False)
 
         # If we want to use child studies (eg. campaign or consortium),
         # find all children for provided study IDs and add them

--- a/tests/test_biosample_manager.py
+++ b/tests/test_biosample_manager.py
@@ -243,3 +243,9 @@ class TestNMDCWorkflowBiosampleManager:
         assert manager.get_biosample_attributes(
             study_ids = ["nmdc:sty-11-srtxhh77"], 
             use_child_studies=True)
+
+        # Test get_get_biosample_attributes with one parent study ID and 
+        # use_child_studies set in configuration rather than provided as argument
+        manager.config["workflow"]["use_child_studies"] = True
+        assert manager.get_biosample_attributes(
+            study_ids = ["nmdc:sty-11-srtxhh77"])

--- a/tests/test_biosample_manager.py
+++ b/tests/test_biosample_manager.py
@@ -229,23 +229,53 @@ class TestNMDCWorkflowBiosampleManager:
         metadata_dir.mkdir(parents=True, exist_ok=True)
 
         # Using real MONet parent and child study IDs
-        # Test get_biosample_attributes with one study ID provided directly
+
+        ###### Test get_biosample_attributes with one study ID provided directly
         assert manager.get_biosample_attributes(study_ids = ["nmdc:sty-11-ygdm6368"])
+
+        # Verify CSV was created - we're going to check and overwrite it a few times
+        csv_path = manager.workflow_path / "metadata" / "biosample_attributes.csv"
+        assert csv_path.exists()
+
+        # Verify CSV contents
+        df = pd.read_csv(csv_path)
+        assert "nmdc:bsm-11-3s3gvn13" in df['id'].values # a known biosample ID
+        assert "nmdc:bsm-11-07spy989" not in df['id'].values # a biosample ID not in this study
+
         manager.set_skip_trigger("biosample_attributes_fetched", False)
 
-        # Test get_biosample_attributes with multiple study IDs
+        ###### Test get_biosample_attributes with multiple study IDs
         assert manager.get_biosample_attributes(
             study_ids = ["nmdc:sty-11-nmtnj115", "nmdc:sty-11-ygdm6368"]
         )
+
+        # Verify CSV contents
+        df = pd.read_csv(csv_path)
+        assert "nmdc:bsm-11-ajv68037" in df['id'].values # a known biosample ID in first study
+        assert "nmdc:bsm-11-3s3gvn13" in df['id'].values # a known biosample ID in second study
+        assert "nmdc:bsm-11-07spy989" not in df['id'].values # a biosample ID not in either study
+
         manager.set_skip_trigger("biosample_attributes_fetched", False)
 
-        # Test get_biosample_attributes with one parent study ID
+        ###### Test get_biosample_attributes with one parent study ID
         assert manager.get_biosample_attributes(
             study_ids = ["nmdc:sty-11-srtxhh77"], 
             use_child_studies=True)
+        
+        # Verify CSV contents
+        df = pd.read_csv(csv_path)
+        assert "nmdc:bsm-11-ajv68037" in df['id'].values # a known biosample ID in a monet child study
+        assert "nmdc:bsm-11-07spy989" not in df['id'].values # a biosample ID not in any monet study
 
-        # Test get_get_biosample_attributes with one parent study ID and 
-        # use_child_studies set in configuration rather than provided as argument
+        manager.set_skip_trigger("biosample_attributes_fetched", False)
+
+        ###### Test get_get_biosample_attributes with one parent study ID and 
+        ###### use_child_studies set in configuration rather than provided as argument
         manager.config["workflow"]["use_child_studies"] = True
         assert manager.get_biosample_attributes(
             study_ids = ["nmdc:sty-11-srtxhh77"])
+    
+        # Verify CSV contents
+        df = pd.read_csv(csv_path)
+        assert "nmdc:bsm-11-ajv68037" in df['id'].values # a known biosample ID in a monet child study
+        assert "nmdc:bsm-11-07spy989" not in df['id'].values # a biosample ID not in any monet study

--- a/tests/test_biosample_manager.py
+++ b/tests/test_biosample_manager.py
@@ -217,3 +217,29 @@ class TestNMDCWorkflowBiosampleManager:
         manager.reset_all_triggers(save=False)
         assert manager.should_skip("biosample_attributes_fetched") is False
         assert manager.should_skip("biosample_mapping_completed") is False
+
+    def test_handling_multiple_study_ids(self, lcms_config_file):
+        """Test that biosample attributes are fetched correctly when multiple study IDs are provided."""
+        from nmdc_dp_utils.workflow_manager import NMDCWorkflowManager
+
+        manager = NMDCWorkflowManager(str(lcms_config_file))
+        
+        # Create metadata directory
+        metadata_dir = manager.workflow_path / "metadata"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+
+        # Using real MONet parent and child study IDs
+        # Test get_biosample_attributes with one study ID provided directly
+        assert manager.get_biosample_attributes(study_ids = ["nmdc:sty-11-ygdm6368"])
+        manager.set_skip_trigger("biosample_attributes_fetched", False)
+
+        # Test get_biosample_attributes with multiple study IDs
+        assert manager.get_biosample_attributes(
+            study_ids = ["nmdc:sty-11-nmtnj115", "nmdc:sty-11-ygdm6368"]
+        )
+        manager.set_skip_trigger("biosample_attributes_fetched", False)
+
+        # Test get_biosample_attributes with one parent study ID
+        assert manager.get_biosample_attributes(
+            study_ids = ["nmdc:sty-11-srtxhh77"], 
+            use_child_studies=True)

--- a/tests/test_workflow_manager.py
+++ b/tests/test_workflow_manager.py
@@ -22,7 +22,7 @@ class TestNMDCWorkflowManager:
         # Verify basic attributes
         assert manager.workflow_name == "test_lcms_workflow"
         assert manager.study_name == "test_lcms_study"
-        assert manager.study_id == "nmdc:sty-11-test"
+        assert manager.study_id == ["nmdc:sty-11-test"]
         assert manager.config_path == str(lcms_config_file.resolve())
         
         # Verify config loaded correctly
@@ -97,7 +97,7 @@ class TestNMDCWorkflowManager:
         
         assert info["workflow_name"] == "test_lcms_workflow"
         assert info["study_name"] == "test_lcms_study"
-        assert info["study_id"] == "nmdc:sty-11-test"
+        assert info["study_id"] == ["nmdc:sty-11-test"]
         assert info["massive_id"] == "MSV000094090"
         assert info["file_type"] == ".raw"
         assert "hilic_pos" in info["configuration_names"]


### PR DESCRIPTION
This PR adds the ability to supply multiple study IDs in the configuration file and/or to include child studies in the list of study IDs, specifically for the purposes of expanding the biosample search.

This is intended for studies that all use the same sample prep protocols. If they use the same sample prep protocols we can generate material processing metadata and run the workflows the same way in the same workflow folder.

The child study search is not recursive, it only looks one level of "part_of" relationships down. This is fine with how NMDC is currently modeling studies, if for some reason we have sub sub sub studies in the future this will need to change, but I don't see that happening...who knows.