### PR TITLE
Upgrade dependencies and clean up post-approval handling of llm-generated content

### DIFF
--- a/nmdc_dp_utils/workflow_manager.py
+++ b/nmdc_dp_utils/workflow_manager.py
@@ -466,14 +466,14 @@ class NMDCWorkflowManager(
         return protocol_info
     
     @skip_if_complete("protocol_outline_created", return_value=True)
-    async def generate_material_processing_yaml(self) -> str:
+    async def generate_material_processing_yaml(self) -> bool:
         """
         Generate material processing YAML using LLM.
 
         Returns
         -------
-        str
-            The generated material processing YAML.
+        bool
+            True if outline generation completed and was approved, False otherwise.
         """
         if self.skip_material_processing():
             self.logger.info(
@@ -498,6 +498,9 @@ class NMDCWorkflowManager(
         approved_outline =  await self.request_approval("protocol outline")
         if approved_outline:
             self.set_skip_trigger("protocol_outline_created", True)
+            return True
+
+        return False
     
     @skip_if_complete("biosample_mapping_completed", return_value=True)
     async def generate_llm_biosample_mapping(self, max_iterations: int = 6) -> bool:
@@ -520,3 +523,6 @@ class NMDCWorkflowManager(
             approved_outline =  await self.request_approval("biosample mapping")
             if approved_outline:
                 self.set_skip_trigger("biosample_mapping_completed", True)
+                return True
+
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 nmdc-mass-spectrometry-metadata-generation @ git+https://github.com/microbiomedata/nmdc_mass_spectrometry_metadata_generation.git@2.9.0
 minio==7.2.20
 miniwdl
-openai==2.44.0
-openai-agents==0.6.5
+openai==2.45.0
+openai-agents==0.18.2
 pytest
 pytest-cov

--- a/workflows/example_gcms_metab/example_gcms_metab_config.json
+++ b/workflows/example_gcms_metab/example_gcms_metab_config.json
@@ -47,16 +47,17 @@
     "skip_triggers": {
         "study_structure_created": true,
         "raw_data_downloaded": true,
+        "protocol_outline_created": true,
         "biosample_attributes_fetched": true,
+        "biosample_mapping_script_generated": false,
         "biosample_mapping_completed": true,
-        "raw_data_inspected": true,
-        "material_processing_metadata_generated": true,
-        "metadata_mapping_generated": true,
-        "data_processed": true,
-        "processed_data_uploaded_to_minio": true,
-        "metadata_packages_generated": true,
-        "metadata_submitted_dev": false,
-        "metadata_submitted_prod": false,
-        "protocol_outline_created": true
+        "raw_data_inspected": false,
+        "data_processed": false,
+        "processed_data_uploaded_to_minio": false,
+        "material_processing_metadata_generated": false,
+        "metadata_mapping_generated": false,
+        "metadata_packages_generated": false,
+        "metadata_submitted_dev": true,
+        "metadata_submitted_prod": true
     }
 }

--- a/workflows/mcmahon_11_fkbnah04_lcms_metab/mcmahon_11_fkbnah04_lcms_metab_config.json
+++ b/workflows/mcmahon_11_fkbnah04_lcms_metab/mcmahon_11_fkbnah04_lcms_metab_config.json
@@ -103,7 +103,6 @@
         "raw_data_downloaded": true,
         "protocol_outline_created": true,
         "biosample_attributes_fetched": true,
-        "biosample_mapping_script_generated": true,
         "biosample_mapping_completed": true,
         "raw_data_inspected": true,
         "data_processed": true,

--- a/workflows/miesel_11_8bjf2432_gcms_metab/miesel_11_8bjf2432_gcms_metab_config.json
+++ b/workflows/miesel_11_8bjf2432_gcms_metab/miesel_11_8bjf2432_gcms_metab_config.json
@@ -48,7 +48,6 @@
         "raw_data_downloaded": true,
         "protocol_outline_created": true,
         "biosample_attributes_fetched": true,
-        "biosample_mapping_script_generated": true,
         "biosample_mapping_completed": true,
         "raw_data_inspected": true,
         "data_processed": true,

--- a/workflows/singer_11_46aje659_lcms_metab/singer_11_46aje659_lcms_metab_config.json
+++ b/workflows/singer_11_46aje659_lcms_metab/singer_11_46aje659_lcms_metab_config.json
@@ -105,7 +105,6 @@
         "raw_data_downloaded": true,
         "protocol_outline_created": true,
         "biosample_attributes_fetched": true,
-        "biosample_mapping_script_generated": false,
         "biosample_mapping_completed": true,
         "raw_data_inspected": true,
         "data_processed": true,


### PR DESCRIPTION
Closes #86

I upgraded both open-ai and open-ai-agents (as suggested by dependabot).

I tested the example gcms workflow parts that use the agents to make sure they still worked as expected.  While testing I noticed a couple small bugs and a legacy trigger name in some of the configs, so I cleaned those up.