### PR TITLE
Add schema validation check for example yamls provided to LLM

### DIFF
--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -45,9 +45,8 @@ jobs:
       - name: Get CODEOWNERS
         id: codeowners
         uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
-        with:
-          path: "tests/test_workflow_manager.py" # needs to be an actual file and all files are covered by CODEOWNERS
-          codeowners: .github/CODEOWNERS
+        with: 
+          path: './.github/CODEOWNERS'
 
       - name: Debug owners
         run: echo "Owners ${CODEOWNERS}"

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -2,10 +2,11 @@
 name: Weekly Jobs
 
 on:
+  push
   schedule:
     # Runs at 03:00 UTC every Monday
     - cron: '0 3 * * 1'
-  workflow_dispatch:  # Optional: lets you run it manually from the Actions tab
+  #workflow_dispatch:  # Optional: lets you run it manually from the Actions tab
 
 jobs:
   weekly-task:
@@ -52,7 +53,7 @@ report-failure:
         path: "/"
 
     - name: Debug owners
-      run: echo "Owners: ${{ steps.codeowners.outputs.codeowners }}"
+      run: echo "Owners ${{ steps.codeowners.outputs.codeowners }}"
 
     - name: Create issue body
       run: |

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -2,7 +2,6 @@
 name: Weekly Jobs
 
 on:
-  push:
   schedule:
     # Runs at 03:00 UTC every Monday
     - cron: '0 3 * * 1'

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -47,6 +47,7 @@ jobs:
         uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
         with:
           path: "tests/test_workflow_manager.py" # needs to be an actual file and all files are covered by CODEOWNERS
+          codeowners: .github/CODEOWNERS
 
       - name: Debug owners
         run: echo "Owners ${CODEOWNERS}"

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -2,6 +2,7 @@
 name: Weekly Jobs
 
 on:
+  push:
   schedule:
     # Runs at 03:00 UTC every Monday
     - cron: '0 3 * * 1'

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -33,26 +33,37 @@ jobs:
       run: |
         pytest tests/test_workflow_manager.py::test_check_protocol_examples_compliance -v --tb=short
 
-  report-failure:
-    needs: weekly-task
-    if: failure()
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Get CODEOWNERS assignees
-        id: codeowners
-        run: bash .github/scripts/get-codeowners-assignees.sh
-      - name: Create issue body
-        run: |
-          echo "The scheduled check on LLM examples' schema compliance failed" > /tmp/issue-body.md
-          echo "" >> /tmp/issue-body.md
-          echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/issue-body.md
-      - name: Create Issue
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
-        with:
-          title: LLM Examples Failed Schema Compliance
-          content-filepath: /tmp/issue-body.md
-          labels: report, automated issue
-          assignees: ${{ steps.codeowners.outputs.assignees }}
+report-failure:
+  needs: weekly-task
+  if: failure()             # runs if *any* needs-job failed
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read          # needed to read CODEOWNERS
+    issues: write           # needed to create issues
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Get CODEOWNERS
+      id: codeowners
+      uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
+      with:
+        path: "/"
+
+    - name: Debug owners
+      run: echo "Owners: ${{ steps.codeowners.outputs.codeowners }}"
+
+    - name: Create issue body
+      run: |
+        echo "The scheduled check on LLM examples' schema compliance failed" > /tmp/issue-body.md
+        echo "" >> /tmp/issue-body.md
+        echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/issue-body.md
+
+    - name: Create Issue
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+      with:
+        title: LLM Examples Failed Schema Compliance
+        content-filepath: /tmp/issue-body.md
+        labels: report, automated issue
+        assignees: ${{ steps.codeowners.outputs.codeowners }}

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -46,7 +46,7 @@ jobs:
         id: codeowners
         uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
         with:
-          path: "/"
+          path: "tests/test_workflow_manager.py" # needs to be an actual file and all files are covered by CODEOWNERS
 
       - name: Debug owners
         run: echo "Owners ${{ steps.codeowners.outputs.codeowners }}"

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -2,28 +2,23 @@
 name: Weekly Jobs
 
 on:
-  push:
   schedule:
     # Runs at 03:00 UTC every Monday
     - cron: '0 3 * * 1'
-  #workflow_dispatch:  # Optional: lets you run it manually from the Actions tab
+  workflow_dispatch:  # Optional: lets you run it manually from the Actions tab
 
 jobs:
   weekly-task:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: ['3.11', '3.12']
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.12
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.12
     
     - name: Install dependencies
       run: |
@@ -44,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get CODEOWNERS
         id: codeowners

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -2,7 +2,7 @@
 name: Weekly Jobs
 
 on:
-  push
+  push:
   schedule:
     # Runs at 03:00 UTC every Monday
     - cron: '0 3 * * 1'

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -48,10 +48,24 @@ jobs:
         with: 
           path: './.github/CODEOWNERS'
 
+      - name: Normalize assignees from CODEOWNERS JSON
+        id: assignees
+        run: |
+          # Raw JSON from basic mode, e.g. {"*":["@test1","@test2"]}
+          raw='${{ steps.codeowners.outputs.codeowners }}'
+
+          # Extract the array for the "*" rule, join with spaces: "@test1 @test2"
+          owners=$(echo "$raw" | jq -r '.["*"] | join(" ")')
+
+          # Strip '@' and convert spaces to commas: "test1,test2"
+          normalized=$(echo "$owners" | tr -d '@' | tr ' ' ',')
+
+          echo "normalized=$normalized" >> "$GITHUB_OUTPUT"
+
       - name: Debug owners
         run: echo "Owners ${CODEOWNERS}"
         env:
-          CODEOWNERS: ${{ steps.codeowners.outputs.codeowners }}
+          CODEOWNERS: ${{ steps.codeowners.outputs.normalized }}
 
       - name: Create issue body
         run: |
@@ -65,4 +79,4 @@ jobs:
           title: LLM Examples Failed Schema Compliance
           content-filepath: /tmp/issue-body.md
           labels: report, automated issue
-          assignees: ${{ steps.codeowners.outputs.codeowners }}
+          assignees: ${{ steps.assignees.outputs.normalized }}

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Run weekly script
       run: |
-        pytest tests/test_workflow_manager.py::test_check_protocol_examples_compliance -v --tb=short
+        pytest tests/test_workflow_manager.py::TestNMDCWorkflowManager::test_check_protocol_examples_compliance -v --tb=short
 
   report-failure:
     needs: weekly-task

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -34,37 +34,37 @@ jobs:
       run: |
         pytest tests/test_workflow_manager.py::test_check_protocol_examples_compliance -v --tb=short
 
-report-failure:
-  needs: weekly-task
-  if: failure()             # runs if *any* needs-job failed
-  runs-on: ubuntu-latest
-  permissions:
-    contents: read          # needed to read CODEOWNERS
-    issues: write           # needed to create issues
+  report-failure:
+    needs: weekly-task
+    if: failure()             # runs if *any* needs-job failed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # needed to read CODEOWNERS
+      issues: write           # needed to create issues
 
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Get CODEOWNERS
-      id: codeowners
-      uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
-      with:
-        path: "/"
+      - name: Get CODEOWNERS
+        id: codeowners
+        uses: SvanBoxel/codeowners-action@f9e9c6a1998e896bb0ca62402497a06cb58e2e5d
+        with:
+          path: "/"
 
-    - name: Debug owners
-      run: echo "Owners ${{ steps.codeowners.outputs.codeowners }}"
+      - name: Debug owners
+        run: echo "Owners ${{ steps.codeowners.outputs.codeowners }}"
 
-    - name: Create issue body
-      run: |
-        echo "The scheduled check on LLM examples' schema compliance failed" > /tmp/issue-body.md
-        echo "" >> /tmp/issue-body.md
-        echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/issue-body.md
+      - name: Create issue body
+        run: |
+          echo "The scheduled check on LLM examples' schema compliance failed" > /tmp/issue-body.md
+          echo "" >> /tmp/issue-body.md
+          echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/issue-body.md
 
-    - name: Create Issue
-      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
-      with:
-        title: LLM Examples Failed Schema Compliance
-        content-filepath: /tmp/issue-body.md
-        labels: report, automated issue
-        assignees: ${{ steps.codeowners.outputs.codeowners }}
+      - name: Create Issue
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: LLM Examples Failed Schema Compliance
+          content-filepath: /tmp/issue-body.md
+          labels: report, automated issue
+          assignees: ${{ steps.codeowners.outputs.codeowners }}

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -1,0 +1,34 @@
+# .github/workflows/weekly-jobs.yml
+name: Weekly Jobs
+
+on:
+  schedule:
+    # Runs at 03:00 UTC every Monday
+    - cron: '0 3 * * 1'
+  workflow_dispatch:  # Optional: lets you run it manually from the Actions tab
+
+jobs:
+  weekly-task:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run weekly script
+      run: |
+        pytest tests/test_workflow_manager.py::test_check_protocol_examples_compliance -v --tb=short

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -32,3 +32,27 @@ jobs:
     - name: Run weekly script
       run: |
         pytest tests/test_workflow_manager.py::test_check_protocol_examples_compliance -v --tb=short
+
+  report-failure:
+    needs: weekly-task
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get CODEOWNERS assignees
+        id: codeowners
+        run: bash .github/scripts/get-codeowners-assignees.sh
+      - name: Create issue body
+        run: |
+          echo "The scheduled check on LLM examples' schema compliance failed" > /tmp/issue-body.md
+          echo "" >> /tmp/issue-body.md
+          echo "**Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/issue-body.md
+      - name: Create Issue
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: LLM Examples Failed Schema Compliance
+          content-filepath: /tmp/issue-body.md
+          labels: report, automated issue
+          assignees: ${{ steps.codeowners.outputs.assignees }}

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -49,7 +49,9 @@ jobs:
           path: "tests/test_workflow_manager.py" # needs to be an actual file and all files are covered by CODEOWNERS
 
       - name: Debug owners
-        run: echo "Owners ${{ steps.codeowners.outputs.codeowners }}"
+        run: echo "Owners ${CODEOWNERS}"
+        env:
+          CODEOWNERS: ${{ steps.codeowners.outputs.codeowners }}
 
       - name: Create issue body
         run: |

--- a/nmdc_dp_utils/llm/examples/example_1/combined_outline.yaml
+++ b/nmdc_dp_utils/llm/examples/example_1/combined_outline.yaml
@@ -13,7 +13,7 @@ NOM:
         - ProcessedSample1_NOM
         - ProcessedSample2_NOM
         - ProcessedSample3_NOM
-        processing_institution: Test
+        processing_institution: EMSL
         mass:
           type: nmdc:QuantityValue
           has_raw_value: 6 g

--- a/nmdc_dp_utils/llm/examples/example_1/combined_outline.yaml
+++ b/nmdc_dp_utils/llm/examples/example_1/combined_outline.yaml
@@ -13,7 +13,7 @@ NOM:
         - ProcessedSample1_NOM
         - ProcessedSample2_NOM
         - ProcessedSample3_NOM
-        processing_institution: EMSL
+        processing_institution: Test
         mass:
           type: nmdc:QuantityValue
           has_raw_value: 6 g

--- a/nmdc_dp_utils/workflow_manager.py
+++ b/nmdc_dp_utils/workflow_manager.py
@@ -482,6 +482,9 @@ class NMDCWorkflowManager(
             self.set_skip_trigger("protocol_outline_created", True)
             return ""
 
+        # check if protocol examples that will be given to LLM are compliant with current schema
+        self.check_protocol_examples_compliance()
+
         # load protocol description into LLM conversation context
         self.load_protocol_description_to_context(
             protocol_description_path=self.workflow_path / "protocol_info" / "protocol_description.txt"

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -5454,7 +5454,42 @@ class LLMWorkflowManagerMixin:
         if self._conversation_obj is None:
             self._conversation_obj = ConversationManager(interaction_type=self._interaction_type)
         return self._conversation_obj
-        
+
+    def check_protocol_examples_compliance(self) -> None:
+        """
+        Check if the protocol examples provided to the LLM are compliant with the current schema.
+
+        Raises:
+            ValueError: If any of the protocol examples are not compliant with the schema.
+        """
+        import logging
+        from nmdc_ms_metadata_gen.validate_yaml_outline import validate_yaml_outline
+
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        try:
+            # Temporarily suppress error logging
+            # so 'Validation Passed!' messages don't clutter the output
+            root_logger.setLevel(logging.WARNING)
+            non_compliant_examples = []
+            dirs = ["nmdc_dp_utils/llm/examples/example_1", "nmdc_dp_utils/llm/examples/example_2", "nmdc_dp_utils/llm/examples/example_3", "nmdc_dp_utils/llm/examples/example_4", "nmdc_dp_utils/llm/examples/example_5", "nmdc_dp_utils/llm/examples/example_6", "nmdc_dp_utils/llm/examples/example_7"]
+            for dir in dirs:
+                all_protocols = validate_yaml_outline(f"{dir}/combined_outline.yaml")
+                for protocol in all_protocols:
+                    if protocol['result'] != "All okay!":
+                        non_compliant_examples.append(dir)
+        finally:
+            # Restore original logging level
+            root_logger.setLevel(original_level)
+
+        if non_compliant_examples:
+            error_message = (
+                "The following protocol examples are not compliant with the current schema:\n"
+                + "\n".join(str(example) for example in non_compliant_examples)
+            )
+            self.logger.error(error_message)
+            raise ValueError(error_message)
+
     def load_protocol_description_to_context(self, protocol_description_path: str) -> None:
         """
         Load protocol description from a text file to the LLM conversation context.

--- a/nmdc_dp_utils/workflow_manager_mixins.py
+++ b/nmdc_dp_utils/workflow_manager_mixins.py
@@ -5455,7 +5455,8 @@ class LLMWorkflowManagerMixin:
             self._conversation_obj = ConversationManager(interaction_type=self._interaction_type)
         return self._conversation_obj
 
-    def check_protocol_examples_compliance(self) -> None:
+    @staticmethod
+    def check_protocol_examples_compliance() -> None:
         """
         Check if the protocol examples provided to the LLM are compliant with the current schema.
 
@@ -5474,9 +5475,9 @@ class LLMWorkflowManagerMixin:
             non_compliant_examples = []
             dirs = ["nmdc_dp_utils/llm/examples/example_1", "nmdc_dp_utils/llm/examples/example_2", "nmdc_dp_utils/llm/examples/example_3", "nmdc_dp_utils/llm/examples/example_4", "nmdc_dp_utils/llm/examples/example_5", "nmdc_dp_utils/llm/examples/example_6", "nmdc_dp_utils/llm/examples/example_7"]
             for dir in dirs:
-                all_protocols = validate_yaml_outline(f"{dir}/combined_outline.yaml")
+                all_protocols = validate_yaml_outline(f"{dir}/combined_outline.yaml", test=True)
                 for protocol in all_protocols:
-                    if protocol['result'] != "All okay!":
+                    if protocol['result'].lower() != "all okay!":
                         non_compliant_examples.append(dir)
         finally:
             # Restore original logging level
@@ -5487,7 +5488,7 @@ class LLMWorkflowManagerMixin:
                 "The following protocol examples are not compliant with the current schema:\n"
                 + "\n".join(str(example) for example in non_compliant_examples)
             )
-            self.logger.error(error_message)
+            logging.getLogger(__name__).error(error_message)
             raise ValueError(error_message)
 
     def load_protocol_description_to_context(self, protocol_description_path: str) -> None:

--- a/tests/test_workflow_manager.py
+++ b/tests/test_workflow_manager.py
@@ -342,3 +342,12 @@ processing_steps:
 
         assert result is True
         assert manager.should_skip("material_processing_metadata_generated") is True
+
+    def test_check_protocol_examples_compliance(self):
+        from nmdc_dp_utils.workflow_manager_mixins import LLMWorkflowManagerMixin
+
+        with patch.dict(
+            "os.environ",
+            {"CLIENT_ID": "test-client-id", "CLIENT_SECRET": "test-client-secret"},
+        ):
+            LLMWorkflowManagerMixin.check_protocol_examples_compliance()


### PR DESCRIPTION
Updates:
- Added `validate_yaml_outline` check on example yamls being provided to LLM before yaml generation (`check_protocol_examples_compliance`)
- Added `test_check_protocol_examples_compliance` to `test_workflow_manager`, which will cause `check_protocol_examples_compliance` to run with GH actions

Note: 
added suppression to logging in `check_protocol_examples_compliance` so terminal output is cleaner and doesn't have a bunch of `Validation Passed!` notifications